### PR TITLE
refactor: ensure compatibility with upcoming MagicMirror² versions

### DIFF
--- a/MMM-HK-Transport-ETA.js
+++ b/MMM-HK-Transport-ETA.js
@@ -37,7 +37,6 @@ Module.register("MMM-HK-Transport-ETA", {
 	getScripts: function () {
 		return [
 			"moment.js",
-			this.file("../default/utils.js"),
 			"hktransportetaprovider.js",
 			"etaobject.js",
 			this.file(

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To add this module, go to MagicMirror folder and run the following command
 
 ```bash
 cd modules
-git clone https://github.com/winstonma/MMM-HK-Transport-ETA.git
+git clone https://github.com/winstonma/MMM-HK-Transport-ETA
 cd MMM-HK-Transport-ETA
 npm install
 ```
@@ -39,7 +39,6 @@ npm install
 To use this module, add it to the modules array in the `config/config.js` file:
 
 ```javascript
-modules: [
 	{
 		module: "MMM-HK-Transport-ETA",
 		position: "top_right",
@@ -49,7 +48,6 @@ modules: [
 			sta: "Hong Kong",
 		},
 	},
-];
 ```
 
 ## Configuration options

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For detailed information on how to use the script, please refer to [scripts/READ
 
 ## Prerequisite
 
-A working installation of [MagicMirror<sup>2</sup>](https://github.com/MichMich/MagicMirror)
+A working installation of [MagicMirror²](https://github.com/MagicMirrorOrg/MagicMirror).
 
 ## Dependencies
 

--- a/hktransportetaprovider.js
+++ b/hktransportetaprovider.js
@@ -1,4 +1,4 @@
-/* global Class, performWebRequest */
+/* global Class */
 
 /* MagicMirror²
  * Module: ETA
@@ -92,16 +92,19 @@ const HKTransportETAProvider = Class.extend({
 			const data = mockData.substring(1, mockData.length - 1);
 			return JSON.parse(data);
 		}
-		const useCorsProxy =
-			typeof this.config.useCorsProxy !== "undefined" &&
-			this.config.useCorsProxy;
-		return performWebRequest(
-			url,
-			type,
-			useCorsProxy,
-			requestHeaders,
-			expectedResponseHeaders,
-		);
+		const headers = {};
+		if (requestHeaders) {
+			requestHeaders.forEach(h => { headers[h.name] = h.value; });
+		}
+		const response = await fetch(url, { headers });
+		if (!response.ok) {
+			throw new Error(`HTTP error: ${response.status}`);
+		}
+		if (type === "xml") {
+			const text = await response.text();
+			return new DOMParser().parseFromString(text, "text/xml");
+		}
+		return response.json();
 	},
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,140 @@
+{
+	"name": "MMM-HK-Transport-ETA",
+	"version": "1.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "MMM-HK-Transport-ETA",
+			"version": "1.0.0",
+			"license": "AGPL-3.0-or-later",
+			"dependencies": {
+				"js-kmb-api": "^3.2.6",
+				"node-storage-shim": "^2.0.1"
+			},
+			"devDependencies": {
+				"prettier": "^3.8.1"
+			}
+		},
+		"node_modules/@coolaj86/urequest": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/@coolaj86/urequest/-/urequest-1.3.7.tgz",
+			"integrity": "sha512-PPrVYra9aWvZjSCKl/x1pJ9ZpXda1652oJrPBYy5rQumJJMkmTBN3ux+sK2xAUwVvv2wnewDlaQaHLxLwSHnIA==",
+			"license": "(MIT OR Apache-2.0)"
+		},
+		"node_modules/aes-js": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+			"integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
+			"license": "MIT"
+		},
+		"node_modules/array-flat-polyfill": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz",
+			"integrity": "sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw==",
+			"license": "CC0-1.0",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/axios": {
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+			"integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+			"license": "MIT",
+			"dependencies": {
+				"follow-redirects": "^1.14.0"
+			}
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.15.11",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+			"integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/hkscs_converter": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/hkscs_converter/-/hkscs_converter-0.2.0.tgz",
+			"integrity": "sha512-1vHKRLNFlTp2Y3RFuVGEdONjP46Wo0VpqN4DOEyj5ZLfzcm5/QQt0EHv5hTCBfiRx7LMLIbqSh0XaZs4beJR3w==",
+			"license": "MIT",
+			"dependencies": {
+				"is-hexadecimal": "^1"
+			},
+			"engines": {
+				"node": ">=5.6.0"
+			}
+		},
+		"node_modules/is-hexadecimal": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/js-kmb-api": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/js-kmb-api/-/js-kmb-api-3.2.6.tgz",
+			"integrity": "sha512-eLxyxo95XMk8dAmQRz0Cs9utwhZ2tDmLPFO+05TUWPKJmg7da8BsCLrA3sewbyIYXJXDXsvhJTpSBNQsfGQkjA==",
+			"license": "MIT",
+			"dependencies": {
+				"aes-js": "^3.1.2",
+				"array-flat-polyfill": "^1.0.1",
+				"axios": "^0.21.1",
+				"hkscs_converter": "^0.2.0",
+				"node-storage-shim": "^2.0.1",
+				"ssl-root-cas": "^1.3.1"
+			}
+		},
+		"node_modules/node-storage-shim": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/node-storage-shim/-/node-storage-shim-2.0.1.tgz",
+			"integrity": "sha512-ce8enbToMe8iUHDTMCg4rdP1K0syoJrZRO0Dl9uMLPCwlc5M1HKaapV3Pqlv6/3LQNuDiYXBm4rPlj78MeUSSA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=6.14.4"
+			}
+		},
+		"node_modules/prettier": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
+		"node_modules/ssl-root-cas": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/ssl-root-cas/-/ssl-root-cas-1.3.1.tgz",
+			"integrity": "sha512-KR8J210Wfvjh+iNE9jcQEgbG0VG2713PHreItx6aNCPnkFO8XChz1cJ4iuCGeBj0+8wukLmgHgJqX+O5kRjPkQ==",
+			"license": "Apache2",
+			"dependencies": {
+				"@coolaj86/urequest": "^1.3.6"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
 		"node-storage-shim": "^2.0.1"
 	},
 	"devDependencies": {
-		"prettier": "^3.0.0"
+		"prettier": "^3.8.1"
 	}
 }


### PR DESCRIPTION
`performWebRequest` will be removed in a future version of MagicMirror² eventually. This PR replaces it with the native `fetch` API to keep the module working going forward — and takes the opportunity to clean up a few
smaller things along the way.

See commit messages for more details :slightly_smiling_face: 