### PR TITLE
refactor: migrate provider base to ES6 class

### DIFF
--- a/hktransportetaprovider.js
+++ b/hktransportetaprovider.js
@@ -1,4 +1,4 @@
-/* global Class */
+/* global cloneObject */
 
 /* MagicMirror²
  * Module: ETA
@@ -8,69 +8,71 @@
  *
  * This class is the blueprint for a HK Transport ETA provider.
  */
-const HKTransportETAProvider = Class.extend({
-	// ETA Provider Properties
-	providerName: null,
-	defaults: {},
+class HKTransportETAProvider {
+	constructor () {
+		// ETA Provider Properties
+		this.providerName = null;
+		this.defaults = {};
 
-	// The following properties have accessor methods.
-	// Try to not access them directly.
-	currentETAArray: null,
+		// The following properties have accessor methods.
+		// Try to not access them directly.
+		this.currentETAArray = null;
 
-	// The following properties will be set automatically.
-	// You do not need to overwrite these properties.
-	config: null,
-	delegate: null,
-	providerIdentifier: null,
+		// The following properties will be set automatically.
+		// You do not need to overwrite these properties.
+		this.config = null;
+		this.delegate = null;
+		this.providerIdentifier = null;
+	}
 
 	// ETA Provider Methods
 	// All the following methods can be overwritten, although most are good as they are.
 
 	// Called when a HK Transport ETA provider is initialized.
-	init: function (config) {
+	init (config) {
 		this.config = config;
 		Log.info(
 			`HK Transport ETA provider: ${this.providerName} initialized.`,
 		);
-	},
+	}
 
 	// Called to set the config, this config is the same as the ETA module's config.
-	setConfig: function (config) {
+	setConfig (config) {
 		this.config = config;
 		Log.info(
 			`HK Transport ETA provider: ${this.providerName} config set.`,
 			this.config,
 		);
-	},
+	}
 
 	// Called when the HK Transport ETA provider is about to start.
-	start: function () {
+	start () {
 		Log.info(`HK Transport ETA provider: ${this.providerName} started.`);
-	},
+	}
 
 	// This method should start the API request to fetch the current ETA.
 	// This method should definitely be overwritten in the provider.
-	fetchETA: function () {
+	fetchETA () {
 		Log.warn(
 			`HK Transport ETA provider: ${this.providerName} does not subclass the fetchETA method.`,
 		);
-	},
+	}
 
 	// This returns the current ETA object for the current ETA.
-	currentETA: function () {
+	currentETA () {
 		return this.currentETAArray;
-	},
+	}
 
 	// Set the currentETA and notify the delegate that new information is available.
-	setCurrentETA: function (currentETAArray) {
+	setCurrentETA (currentETAArray) {
 		// We should check here if we are passing a ETA
 		this.currentETAArray = currentETAArray;
-	},
+	}
 
 	// Notify the delegate that new ETA is available.
-	updateAvailable: function () {
+	updateAvailable () {
 		this.delegate.updateAvailable(this);
-	},
+	}
 
 	/**
 	 * A convenience function to make requests.
@@ -81,7 +83,7 @@ const HKTransportETAProvider = Class.extend({
 	 * @param {Array.<string>} expectedResponseHeaders the expected HTTP headers to recieve
 	 * @returns {Promise} resolved when the fetch is done
 	 */
-	fetchData: async function (
+	async fetchData (
 		url,
 		type = "json",
 		requestHeaders = undefined,
@@ -107,8 +109,8 @@ const HKTransportETAProvider = Class.extend({
 			return new DOMParser().parseFromString(text, "text/xml");
 		}
 		return response.json();
-	},
-});
+	}
+}
 
 /**
  * Collection of registered ETA providers.
@@ -126,7 +128,7 @@ HKTransportETAProvider.register = function (
 	providerDetails,
 ) {
 	HKTransportETAProvider.providers[providerIdentifier.toLowerCase()] =
-		HKTransportETAProvider.extend(providerDetails);
+		providerDetails;
 };
 
 /**
@@ -139,7 +141,9 @@ HKTransportETAProvider.register = function (
 HKTransportETAProvider.initialize = function (providerIdentifier, delegate) {
 	providerIdentifier = providerIdentifier.toLowerCase();
 
-	const provider = new HKTransportETAProvider.providers[providerIdentifier]();
+	const providerDefinition = HKTransportETAProvider.providers[providerIdentifier];
+	const provider = new HKTransportETAProvider();
+	Object.assign(provider, cloneObject(providerDefinition));
 	const config = Object.assign({}, provider.defaults, delegate.config);
 
 	provider.delegate = delegate;


### PR DESCRIPTION
This removes legacy inheritance usage while keeping the existing provider API (`register`/`initialize`) behavior compatible, so current provider files continue to work unchanged.

Also future-proofs the module in case `Class` is removed in an upcoming MagicMirror release.